### PR TITLE
Fix issue where parsing a blank worksheet throws an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ const onLoadEvent = (binary, reader, hideEmptyRows, showNullProperties) => {
 	sheetNames.forEach(name => {
 		const sheet = workbook.Sheets[name];
 		const desiredCells = getDesiredCells(sheet);
+
+		if (!desiredCells) {
+			return parsedXls[name] = [];
+		}
+
 		const lastColRow = getLastRowCol(desiredCells);
 		const columnsAndHeaders = getColumnsAndHeaders(sheet, desiredCells);
 


### PR DESCRIPTION
There is a bug where having an empty worksheet crashes the parser, and the following error is thrown:

![Screen Shot 2022-06-29 at 8 59 49 AM](https://user-images.githubusercontent.com/38885170/176442473-8be57afb-7751-46e6-a7ef-56ca9917ab8b.png)

This occurs because `desiredCells` is `undefined` when the worksheet is empty. In cases like this we can return an empty array instead.

This also fixes: https://github.com/abelalvarez89/xlsx-parse-json/issues/10